### PR TITLE
API reduction

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -104,35 +104,41 @@ true
 
 ## Finding Particles
 
-The `find_particles_by_name` function takes a `String` or a `Regex` to create
-a `Vector` of `Particle`s where the name matches them. If a simple `String`
-is provided, Corpuscles will do a substring search:
+The `particles()` functions returns a `Vector` containing all the particles
+of the currently selected catalog. To search for particles, the `filter()`
+function comes in hand which can be combined with string comparison functions
+like `startswith()` or `occursin()`.
+
+Here is an example how to find all particles with names starting with `"nu"`:
 
 ```julia
-julia> Corpuscles.find_particles_by_name("nu")
+julia> filter(p->startswith(p.name, "nu"), particles())
 6-element Array{Particle,1}:
- Particle(12) 'nu(e)'
- Particle(14) 'nu(mu)'
+ Particle(-14) 'nu(mu)'
  Particle(-16) 'nu(tau)'
  Particle(-12) 'nu(e)'
+ Particle(14) 'nu(mu)'
  Particle(16) 'nu(tau)'
- Particle(-14) 'nu(mu)'
+ Particle(12) 'nu(e)'
 ```
 
-to have more control, use a regular expression:
+A more powerful way to filter particles based
+on patterns in their name is using [regular
+expressions](https://docs.julialang.org/en/v1/manual/strings/#Regular-Expressio ns-1)
+with e.g. `occursin()`:
 
 ```julia
-julia> Corpuscles.find_particles_by_name(r"D\(\d*\)")
+julia> filter(p->occursin(r"D\(\d*\)", p.name), particles())
 10-element Array{Particle,1}:
- Particle(-10411) 'D(0)*(2300)'
- Particle(10423) 'D(1)(2420)'
- Particle(425) 'D(2)*(2460)'
- Particle(10421) 'D(0)*(2300)'
- Particle(-10423) 'D(1)(2420)'
- Particle(-425) 'D(2)*(2460)'
- Particle(10411) 'D(0)*(2300)'
- Particle(415) 'D(2)*(2460)'
  Particle(-10421) 'D(0)*(2300)'
+ Particle(-10411) 'D(0)*(2300)'
+ Particle(425) 'D(2)*(2460)'
+ Particle(10411) 'D(0)*(2300)'
+ Particle(10421) 'D(0)*(2300)'
+ Particle(10423) 'D(1)(2420)'
+ Particle(-425) 'D(2)*(2460)'
+ Particle(-10423) 'D(1)(2420)'
+ Particle(415) 'D(2)*(2460)'
  Particle(-415) 'D(2)*(2460)'
 ```
 

--- a/src/Corpuscles.jl
+++ b/src/Corpuscles.jl
@@ -7,7 +7,7 @@ using Printf
 
 import Base
 
-export Particle, PDGID, PythiaID, Geant3ID
+export Particle, PDGID, PythiaID, Geant3ID, particles
 
 # Julia 1.0 compatibility
 eachrow_(x) = (x[i, :] for i in 1:size(x)[1])
@@ -209,7 +209,17 @@ const _default_catalog = filter(s->occursin(_default_year,s), _catalogs)[end]
 
 mutable struct Catalog
     particle_dict::ParticleDict
+    particles::Vector{Particle}
+
+    Catalog(d::ParticleDict) = new(d, collect(values(d)))
 end
+
+"""
+    particles()
+
+Returns the full list of particles from the currently selected catalog.
+"""
+particles() = catalog.particles
 
 const catalog = Catalog(read_particle_csv(_default_catalog))
 
@@ -227,7 +237,9 @@ julia> Corpuscles.use_catalog_file("/home/foobar/dev/Corpuscles.jl/data/particle
 ```
 """
 function use_catalog_file(filepath::AbstractString)
+    # TODO: there is surely a better way to manage this "closure"-like thing
     catalog.particle_dict = read_particle_csv(filepath)
+    catalog.particles = collect(values(catalog.particle_dict))
     return
 end
 
@@ -262,26 +274,6 @@ function Base.print(io::IO, p::Particle)
             Printf.@printf(io, "%s = %s\n",key, value)
         end
     end
-end
-
-"""
-    find_particles_by_name(name::Regex)
-
-Find particles by their name
-
-# Arguments
-- `name::Union{Regex, AbstractString}`: name search term
-
-# Examples
-```julia-repl
-julia> Corpuscles.find_particles_by_name(r"[A-Z]*mma")
-1-element Array{Particle,1}:
- Particle(22)
-```
-"""
-function find_particles_by_name(name::Union{Regex, AbstractString})
-    dct = filter(x->occursin(name, x.second.name), catalog.particle_dict)
-    collect(values(dct))
 end
 
 end # module


### PR DESCRIPTION
This removes `find_particles_by_name()` and adds a `particles()` function which returns a `Vector{Particle}`. This gives a much more general way to filter particles.

What do you think? We can still add functions which specifically search by name etc. 