### PR TITLE
Update version bounds for Unitful and increase package version

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -10,7 +10,7 @@ Unitful = "1986cc42-f94f-5a68-af5c-568840ba703d"
 UnitfulAtomic = "a7773ee8-282e-5fa2-be4e-bd808c38a91a"
 
 [compat]
-Unitful = "0.18"
+Unitful = "0.18, 1"
 UnitfulAtomic = "0.3.0"
 julia = "1"
 

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Corpuscles"
 uuid = "e78a0372-c628-4773-9c8d-eb17d149bf93"
 authors = ["Johannes Schumann", "Tamas Gal"]
-version = "0.2.1"
+version = "0.2.2"
 
 [deps]
 DelimitedFiles = "8bb1440f-4735-579b-a4ab-409b98df4dab"


### PR DESCRIPTION
Corpuscles is currently blocking updating Unitful to v1.